### PR TITLE
Added: Correct regexp for WWDC2014 (fixes #11)

### DIFF
--- a/wwdcVideoPDFGet-curlVersion.sh
+++ b/wwdcVideoPDFGet-curlVersion.sh
@@ -160,7 +160,16 @@ doGetWWDCPost2012 () {
     cat ${TMP_DIR}/video.html | grep -o -E 'href="(http:\/\/devstreaming.apple.com\/videos\/wwdc\/'${YEAR}'/'${REGEXFILE}'\?dl=1+)"' | cut -d'"' -f2 | while read line; do 
 
     echo $line
-    session_number=`echo $line | grep -o -E '/[0-9]+-'${FORMAT}'.mov' | grep -o -E [0-9]+`
+    if [ ${YEAR} = "2013" ];
+    then
+      session_number=`echo $line | grep -o -E '/[0-9]+-'${FORMAT}'.mov' | grep -o -E [0-9]+`
+    elif [ ${YEAR} = "2014" ];
+    then
+      session_number=`echo $line | grep -o -i -E '/[0-9]+_'${FORMAT}'[^/]+.mov' | grep -o -E [0-9]+`
+    else
+      session_number=000
+    fi
+
         if [ ${SELECTIVE_SESSION_MODE} == true ];
         then
             if `echo ${SESSION_WANTED} | grep "${session_number}" 1>/dev/null 2>&1`


### PR DESCRIPTION
The format of the video urls is different this year. The change fixes #11 as well.
