### PR TITLE
Added: Correct regexp for WWDC2014 (fixes #11)

### DIFF
--- a/wwdcVideoPDFGet-curlVersion.sh
+++ b/wwdcVideoPDFGet-curlVersion.sh
@@ -160,7 +160,7 @@ doGetWWDCPost2012 () {
     cat ${TMP_DIR}/video.html | grep -o -E 'href="(http:\/\/devstreaming.apple.com\/videos\/wwdc\/'${YEAR}'/'${REGEXFILE}'\?dl=1+)"' | cut -d'"' -f2 | while read line; do 
 
     echo $line
-    session_number=`echo $line | grep -o -i -E '/[0-9]+[_-]'${FORMAT}'[^/]*.mov' | grep -o -E '[0-9]+'`
+    session_number=`echo $line | grep -o -i -E '/[0-9]+[_-]'${FORMAT}'[^/]*.mov' | grep -o -E '[0-9]+' | head -1`
         if [ ${SELECTIVE_SESSION_MODE} == true ];
         then
             if `echo ${SESSION_WANTED} | grep "${session_number}" 1>/dev/null 2>&1`


### PR DESCRIPTION
The format of the video urls is different this year.

```
http://devstreaming.apple.com/videos/wwdc/2014/712xx1pl2u942g2/712/712_hd_writing_energy_efficient_code_part_2.mov?dl=1
```
- uses underscores instead of hyphens
- might contain text after `123_hd`, see `712_hd_writing_energy_efficient_code_part_2`
- format is lower-case (so we need to use `grep -i`)

Note: I closed my previous pull-request #13 because it did an unnecessary if/else - this pr only modifies the regular expression.
