### PR TITLE
Avoid matching "http_" in session names

### DIFF
--- a/wwdc2016.swift
+++ b/wwdc2016.swift
@@ -184,7 +184,7 @@ class DownloadSessionManager : NSObject, NSURLSessionDownloadDelegate {
 
 class wwdcVideosController {
     class func getHDorSDdURLsFromStringAndFormat(testStr: String, format: VideoQuality) -> (String) {
-        let pat = "\\b.*(http.*" + format.rawValue + ".*\\.mp4)\\b"
+        let pat = "\\b.*(http[^_].*" + format.rawValue + ".*\\.mp4)\\b"
         let regex = try! NSRegularExpression(pattern: pat, options: [])
         let matches = regex.matchesInString(testStr, options: [], range: NSRange(location: 0, length: testStr.characters.count))
         var videoURL = ""
@@ -199,7 +199,7 @@ class wwdcVideosController {
     }
     
     class func getPDFResourceURLFromString(testStr: String) -> (String) {
-        let pat = "\\b.*(http.*\\.pdf)\\b"
+        let pat = "\\b.*(http[^_].*\\.pdf)\\b"
         let regex = try! NSRegularExpression(pattern: pat, options: [])
         let matches = regex.matchesInString(testStr, options: [], range: NSRange(location: 0, length: testStr.characters.count))
         var pdfResourceURL = ""


### PR DESCRIPTION
If you try to download all the PDFs, the process stops at the session 504 with the following error:

```
[Session 504] Getting http_live_streaming.pdf (http_live_streaming.pdf):

Ooops! Something went wrong: unsupported URL
retrying file download...
```

That's because the pattern `http.*\\.pdf` used in `getPDFResourceURLFromString()` matches the partial "`http_`" string in the middle of the session names.
