### PR TITLE
Supported for Xcode 8

### DIFF
--- a/wwdc2016.swift
+++ b/wwdc2016.swift
@@ -1,4 +1,4 @@
-#!/usr/bin/env xcrun swift
+#!/usr/bin/env xcrun --toolchain "com.apple.dt.toolchain.Swift_2_3" swift
 
 /*
 	Author: Olivier HO-A-CHUCK


### PR DESCRIPTION
I have installed Xcode 8 and was trying to download the videos but the script was giving some syntax error due to changes in Swift-3. 

I have temporarily changed the swift version 2.3 so that everyone can be able to download the videos from this script.

Please let me know in case any other changes required.