### PR TITLE
index is not used when walking the results, so replaced with _ to dro…

### DIFF
--- a/wwdc2017.swift
+++ b/wwdc2017.swift
@@ -492,7 +492,7 @@ if sessionsSet.count != 0 {
 
 sessionsListArray.sort(by: sortFunc)
 
-for (index, value) in sessionsListArray.enumerated() {
+for (_, value) in sessionsListArray.enumerated() {
     let htmlText = wwdcVideosController.getStringContent(fromURL: "https://developer.apple.com/videos/play/wwdc2017/" + value + "/")
 
     let title = wwdcVideosController.getTitle(fromHTML: htmlText)


### PR DESCRIPTION
…p swift runtime warning. Warning began after installing xcode 9 beta which installed Swift 4 on OSX.  If someone who has not installed xcode 9 beta and still have swift 3 installed could test, that be great.

Ref: Apple Swift version 4.0 (swiftlang-900.0.43 clang-900.0.22.8)