### PR TITLE
Added a new param --list-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ downloads by default WWDC 2017 HD videos sessions.
 ### Options
 You can try `wwdc2016.swift --help` for more options.
 
-Usage: 	wwdc2017.swift [--hd] [--sd] [--pdf] [--pdf-only] [--sessions <s1 s2 ...>] [--help]
+Usage: 	wwdc2017.swift [--hd] [--sd] [--pdf] [--pdf-only] [--sessions <s1 s2 ...>] [--list-only] [--help]
 
 Examples:
 
@@ -40,6 +40,9 @@ Examples:
 
 		- Download only SD videos + PDFs for sessions 503 and 504 for wwdc 2017:
 			./wwdc2017.swift --sd --pdf --sessions 503 504
+
+		- List titles of known sessions for wwdc 2017:
+			./wwdc2017.swift --list-only
 
 ### Requirements
 Works on macOS.

--- a/wwdc2017.swift
+++ b/wwdc2017.swift
@@ -393,7 +393,7 @@ class wwdcVideosController {
 
 func showHelpAndExit() {
     print("wwdc2017 - a simple swifty video sessions bulk download.\nJust Get'em all!")
-    print("usage: wwdc2017.swift [--hd] [--sd] [--pdf] [--pdf-only] [--sessions] [--sample] [--help]\n")
+    print("usage: wwdc2017.swift [--hd] [--sd] [--pdf] [--pdf-only] [--sessions] [--sample] [--list-only] [--help]\n")
     exit(0)
 }
 
@@ -440,7 +440,11 @@ for argument in arguments {
     case "--sessions", "-s":
         gettingSessions = true
         break
-        
+    
+    case "--list-only", "-l":
+        shouldDownloadVideoResource = false
+        break;
+
     case _ where Int(argument) != nil:
         if(!gettingSessions) {
             fallthrough


### PR DESCRIPTION
This option just prints the titles of the known sessions to the console.
Great way to see what videos apple has managed to get uploaded during the conference, and can browse to find a session number you may want to grab for offline viewing.

Future expansion could have it display if video, pdfs, samples are available for each