### PR TITLE
In order to run these files on a machine with Xcode 9 developer tools…

### DIFF
--- a/wwdc2016.swift
+++ b/wwdc2016.swift
@@ -1,4 +1,4 @@
-#!/usr/bin/swift
+#!/usr/bin/swift -swift-version 3
 
 /*
 	Author: Olivier HO-A-CHUCK

--- a/wwdc2017.swift
+++ b/wwdc2017.swift
@@ -1,4 +1,4 @@
-#!/usr/bin/swift
+#!/usr/bin/swift -swift-version 3
 
 /*
 	Author: Olivier HO-A-CHUCK


### PR DESCRIPTION
… or later, the Swift version must be specified to support older Swift 3 sources.