### PR TITLE
Fix issue where download video is without sound.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,19 +11,19 @@ Latest version is **wwdcDownloader.swift**.
 
 Ok, this script is not the best in class solution for getting WWDC videos and other resources. There are multiple version of scripts that does the same out there. But the best in class reference is the nice designed mac application done by [Guilherme Rambo](https://github.com/insidegui) : [WWDC](https://github.com/insidegui/WWDC). You definitely want to check he's [website](https://wwdc.io).
 
-The current scripts was mainly created to get in one shot all videos at the end of DubDubDC right before you run back home (in an external hard drive for instance). It's a good move to take benefice of WWDC conference center fast cable connection.
+The current scripts was mainly created to get in one shot all videos at the end of DubDubDC right before you run back home (in an external hard drive for instance). It's a good move to take advantage of WWDC conference center fast cable connection.
 
 Using the options below, you can choose to retrieve 1080p, 720p or SD videos and request to download pdf and sample codes as well.
 
 Note: script will download videos/pdfs in the current directory.
 
-#### Important notice: 1080p videos
-Downloading 1080p videos requires video processing. The script will attempt to use `ffmpeg` if available but will fallback to using macOS included `avconvert`. `avconvert` included with macOS don't seem to support copy mode and would force the video to be re-encoded. It will take significantly longer to process. You are encouraged to [install ffmpeg](http://brewformulas.org/Ffmpeg) (brew install ffmpeg) if you are donwloading the 1080p videos. 
+#### 1080p videos
+Downloading 1080p videos requires video processing. The script will attempt to use `ffmpeg` if available otherwise, will download the stream files but will not convert. The conversion process can be started after all videos are downloaded. After installing `ffmpeg`, re-running `wwdcDownloader` the same way as the first time will only convert the downloaded stream files to video files. You can install `ffmpeg` via  [Homebrew (ffmpeg)] (https://formulae.brew.sh/formula/ffmpeg) (brew install ffmpeg) if you are downloading the 1080p videos. 
 
 ### Usage
 `./wwdcDownloader.swift`
 
-downloads by default WWDC 2019 HD videos sessions.
+Downloads by default WWDC 2019 HD videos sessions.
 
 ### Options
 You can try `wwdcDownloader.swift --help` for more options.
@@ -60,7 +60,8 @@ Examples:
 			./wwdcDownloader.swift --wwdc-year 2019
 
 ### Requirements
-Works on macOS.
+* Works on macOS.
+* ffmpeg (for 1080 HD videos).
 
 
 ### Related content


### PR DESCRIPTION
This year, Apple has split the audio track into a separate stream, so the audio track has to be downloaded separately.

Unfortunately, with this change, I've not figured how to make `avconvert` to do the same merging of the audio and video track. So, that part is taken out from the script until the time I've found how to get `avconvert` to work the same as ffmpeg.