### PR TITLE
improved shell script availability.

### DIFF
--- a/wwdcDownloader.sh
+++ b/wwdcDownloader.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
-/usr/bin/swiftc ./wwdcDownloader.swift && ./wwdcDownloader "$@"
+SCRIPT_DIR=$(cd $(dirname $0); pwd)
+
+/usr/bin/swiftc $SCRIPT_DIR/wwdcDownloader.swift && ./wwdcDownloader "$@"
 


### PR DESCRIPTION
If current directory is different from that of `wwdcDownloader.sh`, the script aborts with the following error.

```sh
% wwdcDownloader.sh --pdf-only
<unknown>:0: error: no such file or directory: './wwdcDownloader.swift'
```

The reason is the path for `wwdcDownloader.swift` is not `.`.

Therefore I improved the script so that we can download the above situation.