### PR TITLE
Fix support for multiple sessions

### DIFF
--- a/wwdcDownloader.swift
+++ b/wwdcDownloader.swift
@@ -881,6 +881,14 @@ while let argument = iterator.next() {
         break
 
     default:
+	if gettingSessions {
+            if Int(argument) != nil {
+                sessionsSet.insert(argument)
+                break
+            } else {
+                gettingSessions = false
+            }
+        }
         print("\(argument) is not a \(#file) command.\n")
         showHelpAndExit()
     }


### PR DESCRIPTION
I was trying to download multiple sessions at once but the script was failing. I checked the code and this is the solution I've found. Just check on the default case if we're still iterating over sessions. Maybe there's a better way to fix it.