### PR TITLE
Fix the shell script wrapper

### DIFF
--- a/wwdcDownloader.sh
+++ b/wwdcDownloader.sh
@@ -2,5 +2,5 @@
 
 SCRIPT_DIR=$(cd $(dirname $0); pwd)
 
-/usr/bin/swiftc $SCRIPT_DIR/wwdcDownloader.swift && ./wwdcDownloader "$@"
+/usr/bin/swiftc "$SCRIPT_DIR/wwdcDownloader.swift" && ./wwdcDownloader "$@"
 


### PR DESCRIPTION
The wrapper script didn't handle being run from a folder whose path contains spaces.